### PR TITLE
riscv: remove `vexriscv` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ repository = "https://github.com/im-tomu/fomu-pac-rs"
 
 [dependencies]
 bare-metal = "0.2.0"
-vexriscv = "0.0.1"
+riscv = "0.6"
 vcell = "0.1.0"
 
 [dependencies.fomu-rt]
 optional = true
-version = "0.0.3"
+version = "0.0.5"
 
 [features]
 rt = ["fomu-rt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fomu-pac"
-version = "0.0.3"
+version = "0.0.4"
 description = "svd2rust generated pac for the fomu"
 license = "Apache-2.0"
 authors = ["David Sawatzke <david-sawatzke@users.noreply.github.com>"]
@@ -16,7 +16,7 @@ vcell = "0.1.0"
 
 [dependencies.fomu-rt]
 optional = true
-version = "0.0.5"
+version = "0.0.6"
 
 [features]
 rt = ["fomu-rt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![allow(non_camel_case_types)]
 #![no_std]
 extern crate bare_metal;
-extern crate vexriscv as riscv;
+extern crate riscv;
 #[cfg(feature = "rt")]
 extern crate fomu_rt as riscv_rt;
 extern crate vcell;


### PR DESCRIPTION
The vexriscv crate has been simplified as a result of
https://github.com/xobs/vexriscv-rust/commit/ba269ff348033e68f7f474353993bd5d32d93c3c.
This removed a lot of duplicate code, under the theory that developers
would use `riscv` for common functions, and processor-specific crates
for processor-specific functions.

This patchset switches back to using `riscv`.

This is required as this no longer builds on nightly due to the renaming of `asm!()` to `llvm_asm!()`,
which necessitates reworking the `vexriscv` crate.

This fixes #2 